### PR TITLE
Prepare for public

### DIFF
--- a/data-preprocess.py
+++ b/data-preprocess.py
@@ -12,12 +12,12 @@ from helpers import get_run_identification
 
 class DataPreprocessor:
     def __init__(self, args):
-        self.data_path = args.data_path
+        self.data_path = args.data_path or valohai.inputs('dataset').path()
         self.model_max_length = args.model_max_length
         self.tokenizer = args.tokenizer
-        self.train_dataset = load_dataset('csv', data_files=valohai.inputs('dataset').path('train.csv'))
-        self.eval_dataset = load_dataset('csv', data_files=valohai.inputs('dataset').path('validation.csv'))
-        self.test_dataset = load_dataset('csv', data_files=valohai.inputs('dataset').path('test.csv'))
+        self.train_dataset = load_dataset('csv', data_files=os.path.join(self.data_path, 'train.csv'))
+        self.eval_dataset = load_dataset('csv', data_files=os.path.join(self.data_path, 'validation.csv'))
+        self.test_dataset = load_dataset('csv', data_files=os.path.join(self.data_path, 'test.csv'))
 
     def prepare_datasets(self, generate_and_tokenize_prompt):
         tknzd_train_dataset = self.train_dataset.map(generate_and_tokenize_prompt)

--- a/data-preprocess.py
+++ b/data-preprocess.py
@@ -15,9 +15,17 @@ class DataPreprocessor:
         self.data_path = args.data_path or os.path.dirname(valohai.inputs('dataset').path())
         self.model_max_length = args.model_max_length
         self.tokenizer = args.tokenizer
-        self.train_dataset = load_dataset('csv', data_files=os.path.join(self.data_path, 'train.csv'))
-        self.eval_dataset = load_dataset('csv', data_files=os.path.join(self.data_path, 'validation.csv'))
-        self.test_dataset = load_dataset('csv', data_files=os.path.join(self.data_path, 'test.csv'))
+        dataset = load_dataset(
+            'csv',
+            data_files={
+                'train': os.path.join(self.data_path, 'train.csv'),
+                'val': os.path.join(self.data_path, 'validation.csv'),
+                'test': os.path.join(self.data_path, 'test.csv'),
+            },
+        )
+        self.train_dataset = dataset['train']
+        self.eval_dataset = dataset['val']
+        self.test_dataset = dataset['test']
 
     def prepare_datasets(self, generate_and_tokenize_prompt):
         tknzd_train_dataset = self.train_dataset.map(generate_and_tokenize_prompt)

--- a/data-preprocess.py
+++ b/data-preprocess.py
@@ -33,10 +33,7 @@ class DataPreprocessor:
         return tknzd_train_dataset, tknzd_val_dataset
 
     def generate_and_tokenize_prompt(self, data_point, tokenizer):
-        full_prompt = f"""Given a target sentence construct the underlying meaning representation of the input sentence as a single function with attributes and attribute values.
-        This function should describe the target string accurately and the function must be one of the following ['inform', 'request', 'give_opinion', 'confirm', 'verify_attribute', 'suggest', 'request_explanation', 'recommend', 'request_attribute'].
-        The attributes must be one of the following: ['name', 'exp_release_date', 'release_year', 'developer', 'esrb', 'rating', 'genres', 'player_perspective', 'has_multiplayer', 'platforms', 'available_on_steam', 'has_linux_release', 'has_mac_release', 'specifier']
-
+        full_prompt = f"""Given a meaning representation generate a target sentence that utilizes the attributes and attribute values given. The sentence should use all the information provided in the meaning representation.
         ### Target sentence:
         {data_point["ref"]}
 

--- a/data-preprocess.py
+++ b/data-preprocess.py
@@ -12,12 +12,12 @@ from helpers import get_run_identification
 
 class DataPreprocessor:
     def __init__(self, args):
-        self.data_path = args.data_path or valohai.inputs('dataset').path()
+        self.data_path = args.data_path
         self.model_max_length = args.model_max_length
         self.tokenizer = args.tokenizer
-        self.train_dataset = load_dataset(self.data_path, split='train')
-        self.eval_dataset = load_dataset(self.data_path, split='validation')
-        self.test_dataset = load_dataset(self.data_path, split='test')
+        self.train_dataset = load_dataset('csv', data_files=valohai.inputs('dataset').path('train.csv'))
+        self.eval_dataset = load_dataset('csv', data_files=valohai.inputs('dataset').path('validation.csv'))
+        self.test_dataset = load_dataset('csv', data_files=valohai.inputs('dataset').path('test.csv'))
 
     def prepare_datasets(self, generate_and_tokenize_prompt):
         tknzd_train_dataset = self.train_dataset.map(generate_and_tokenize_prompt)
@@ -30,10 +30,10 @@ class DataPreprocessor:
         The attributes must be one of the following: ['name', 'exp_release_date', 'release_year', 'developer', 'esrb', 'rating', 'genres', 'player_perspective', 'has_multiplayer', 'platforms', 'available_on_steam', 'has_linux_release', 'has_mac_release', 'specifier']
 
         ### Target sentence:
-        {data_point["target"]}
+        {data_point["ref"]}
 
         ### Meaning representation:
-        {data_point["meaning_representation"]}
+        {data_point["mr"]}
         """
         return tokenizer(full_prompt, truncation=True, max_length=self.model_max_length, padding='max_length')
 

--- a/data-preprocess.py
+++ b/data-preprocess.py
@@ -12,7 +12,7 @@ from helpers import get_run_identification
 
 class DataPreprocessor:
     def __init__(self, args):
-        self.data_path = args.data_path or valohai.inputs('dataset').path()
+        self.data_path = args.data_path or os.path.dirname(valohai.inputs('dataset').path())
         self.model_max_length = args.model_max_length
         self.tokenizer = args.tokenizer
         self.train_dataset = load_dataset('csv', data_files=os.path.join(self.data_path, 'train.csv'))

--- a/finetune-mistral.py
+++ b/finetune-mistral.py
@@ -128,7 +128,7 @@ class FineTuner:
                 optim=self.optimizer,
                 logging_dir='./logs',  # Directory for storing logs
                 save_strategy='steps',  # Save the model checkpoint every logging step
-                save_steps=10,  # Save checkpoints every 50 steps
+                save_steps=50,  # Save checkpoints every 50 steps
                 evaluation_strategy='steps',  # Evaluate the model every logging step
                 eval_steps=50,  # Evaluate and save checkpoints every 50 steps
                 do_eval=self.do_eval,  # Perform evaluation at the end of training

--- a/finetune-mistral.py
+++ b/finetune-mistral.py
@@ -128,9 +128,9 @@ class FineTuner:
                 optim=self.optimizer,
                 logging_dir='./logs',  # Directory for storing logs
                 save_strategy='steps',  # Save the model checkpoint every logging step
-                save_steps=50,  # Save checkpoints every 50 steps
+                save_steps=10,  # Save checkpoints every 10 steps
                 evaluation_strategy='steps',  # Evaluate the model every logging step
-                eval_steps=50,  # Evaluate and save checkpoints every 50 steps
+                eval_steps=17,  # Evaluate and save checkpoints every 17 steps
                 do_eval=self.do_eval,  # Perform evaluation at the end of training
                 report_to=None,
             ),

--- a/inference-mistral.py
+++ b/inference-mistral.py
@@ -39,18 +39,7 @@ class ModelInference:
 
     def postprocess(self, original_string):
         return original_string.strip()
-
-    def prepare_prompt(self, prompt):
-        test_prompt = f"""Given a target sentence construct the underlying meaning representation of the input sentence as a single function with attributes and attribute values.
-        This function should describe the target string accurately and the function must be one of the following ['inform', 'request', 'give_opinion', 'confirm', 'verify_attribute', 'suggest', 'request_explanation', 'recommend', 'request_attribute'].
-        The attributes must be one of the following: ['name', 'exp_release_date', 'release_year', 'developer', 'esrb', 'rating', 'genres', 'player_perspective', 'has_multiplayer', 'platforms', 'available_on_steam', 'has_linux_release', 'has_mac_release', 'specifier']
-
-        ### Target sentence:
-            {prompt}
-        ### Meaning representation:
-        """
-        return self.tokenizer(test_prompt, return_tensors='pt')
-
+        
 
 def run(args):
     inference = ModelInference(

--- a/inference-mistral.py
+++ b/inference-mistral.py
@@ -32,18 +32,13 @@ class ModelInference:
             logger.info('Generating up to %d tokens...', max_tokens)
             outputs = self.ft_model.generate(**inputs, max_length=max_tokens, pad_token_id=2)
         logger.info('Decoding...')
-        return self.tokenizer.decode(outputs[0], skip_special_tokens=True)
+        return self.postprocess(self.tokenizer.decode(outputs[0], skip_special_tokens=True))
 
     def prepare_prompt(self, prompt):
-        test_prompt = f"""Given a target sentence construct the underlying meaning representation of the input sentence as a single function with attributes and attribute values.
-        This function should describe the target string accurately and the function must be one of the following ['inform', 'request', 'give_opinion', 'confirm', 'verify_attribute', 'suggest', 'request_explanation', 'recommend', 'request_attribute'].
-        The attributes must be one of the following: ['name', 'exp_release_date', 'release_year', 'developer', 'esrb', 'rating', 'genres', 'player_perspective', 'has_multiplayer', 'platforms', 'available_on_steam', 'has_linux_release', 'has_mac_release', 'specifier']
+        return self.tokenizer(prompt, return_tensors='pt')
 
-        ### Target sentence:
-            {prompt}
-        ### Meaning representation:
-        """
-        return self.tokenizer(test_prompt, return_tensors='pt')
+    def postprocess(self, original_string):
+        return original_string.strip()
 
 
 def run(args):

--- a/inference-mistral.py
+++ b/inference-mistral.py
@@ -3,6 +3,7 @@ import logging
 
 import torch
 import transformers
+import datasets
 from peft import PeftModel
 
 from helpers import get_quantization_config
@@ -27,12 +28,23 @@ class ModelInference:
         self.ft_model = PeftModel.from_pretrained(model, checkpoint_path).eval()
 
     def generate_response(self, prompt: str, max_tokens: int = 50) -> str:
-        inputs = self.tokenizer(prompt, return_tensors='pt')
+        inputs = self.prepare_prompt(prompt)
         with torch.no_grad():
             logger.info('Generating up to %d tokens...', max_tokens)
             outputs = self.ft_model.generate(**inputs, max_length=max_tokens, pad_token_id=2)
         logger.info('Decoding...')
         return self.tokenizer.decode(outputs[0], skip_special_tokens=True)
+
+    def prepare_prompt(self, prompt):
+        test_prompt = f"""Given a target sentence construct the underlying meaning representation of the input sentence as a single function with attributes and attribute values.
+        This function should describe the target string accurately and the function must be one of the following ['inform', 'request', 'give_opinion', 'confirm', 'verify_attribute', 'suggest', 'request_explanation', 'recommend', 'request_attribute'].
+        The attributes must be one of the following: ['name', 'exp_release_date', 'release_year', 'developer', 'esrb', 'rating', 'genres', 'player_perspective', 'has_multiplayer', 'platforms', 'available_on_steam', 'has_linux_release', 'has_mac_release', 'specifier']
+
+        ### Target sentence:
+            {prompt}
+        ### Meaning representation:
+        """
+        return self.tokenizer(test_prompt, return_tensors='pt')
 
 
 def run(args):
@@ -52,11 +64,12 @@ def main():
     logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser(description='Fine-tuned Model Inference')
     # fmt: off
-    parser.add_argument('--base_mistral_model', type=str, default='mistralai/Mistral-7B-v0.1', help='Base mistral from hugging face')
+    parser.add_argument('--base_mistral_model', type=str, default='mistralai/Mistral-7B-v0.1',
+                        help='Base mistral from hugging face')
     parser.add_argument('--checkpoint_path', default='/valohai/inputs/finetuned-checkpoint/')
     parser.add_argument('--max_tokens', type=int, default=305, help='Maximum number of tokens in response')
     parser.add_argument('--model_path', default='/valohai/inputs/model-base/')
-    parser.add_argument('--prompt', type=str, required=True, help='Input prompt for text generation')
+    parser.add_argument('--prompt', type=str, help='Input prompt for text generation')
     # fmt: on
 
     args = parser.parse_args()

--- a/inference-mistral.py
+++ b/inference-mistral.py
@@ -39,7 +39,7 @@ class ModelInference:
 
     def postprocess(self, original_string):
         return original_string.strip()
-        
+
 
 def run(args):
     inference = ModelInference(

--- a/inference-mistral.py
+++ b/inference-mistral.py
@@ -3,7 +3,6 @@ import logging
 
 import torch
 import transformers
-import datasets
 from peft import PeftModel
 
 from helpers import get_quantization_config
@@ -64,12 +63,11 @@ def main():
     logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser(description='Fine-tuned Model Inference')
     # fmt: off
-    parser.add_argument('--base_mistral_model', type=str, default='mistralai/Mistral-7B-v0.1',
-                        help='Base mistral from hugging face')
+    parser.add_argument('--base_mistral_model', type=str, default='mistralai/Mistral-7B-v0.1', help='Base mistral from hugging face')
     parser.add_argument('--checkpoint_path', default='/valohai/inputs/finetuned-checkpoint/')
     parser.add_argument('--max_tokens', type=int, default=305, help='Maximum number of tokens in response')
     parser.add_argument('--model_path', default='/valohai/inputs/model-base/')
-    parser.add_argument('--prompt', type=str, help='Input prompt for text generation')
+    parser.add_argument('--prompt', type=str, required=True, help='Input prompt for text generation')
     # fmt: on
 
     args = parser.parse_args()

--- a/valohai.yaml
+++ b/valohai.yaml
@@ -1,6 +1,6 @@
 - step:
     name: data-preprocess
-    image: sofiiavalohai/llm-toolkit:v1.0
+    image: valohai/llm-toolkit:0.1
     environment: staging-aws-eu-west-1-p3-2xlarge
     command:
       - pip install -r requirements.in
@@ -15,14 +15,13 @@
     inputs:
       - name: dataset
         default:
-        - s3://dd-sample-bucket/mistral/gem-viggo-dataset/viggo.py
         - s3://dd-sample-bucket/mistral/gem-viggo-dataset/test.csv
         - s3://dd-sample-bucket/mistral/gem-viggo-dataset/train.csv
         - s3://dd-sample-bucket/mistral/gem-viggo-dataset/validation.csv
 
 - step:
     name: finetune
-    image: sofiiavalohai/llm-toolkit:v1.0
+    image: valohai/llm-toolkit:0.1
     environment: staging-aws-eu-west-1-p3-2xlarge
     command:
       - pip install -r requirements.in
@@ -41,7 +40,7 @@
         default: 5
       - name: max_steps
         type: integer
-        default: 15
+        default: 128
       - name: learning_rate
         type: float
         default: 2.5e-5
@@ -58,7 +57,7 @@
 
 - step:
     name: inference
-    image: sofiiavalohai/llm-toolkit:v1.0
+    image: valohai/llm-toolkit:0.1
     environment: staging-aws-eu-west-1-p3-2xlarge
     command:
       - pip install -r requirements.in
@@ -68,15 +67,13 @@
         default: "mistralai/Mistral-7B-v0.1"
       - name: prompt
         type: string
-        default: "give_opinion(name[SpellForce 3], rating[poor], genres[real-time strategy, role-playing], player_perspective[bird view])"
+        default: "You mean Tony Hawk's Pro Skater 3, the 2001 sports game?"
       - name: max_tokens
         type: integer
-        default: 305
+        default: 150
     inputs:
       - name: finetuned-checkpoint
         default: dataset://mistral-models/best_mistral_checkpoint
-      - name: test_data
-        default: dataset://viggo/dev_test
 
 - pipeline:
     name: training-pipeline

--- a/valohai.yaml
+++ b/valohai.yaml
@@ -40,7 +40,7 @@
         default: 5
       - name: max_steps
         type: integer
-        default: 128
+        default: 36
       - name: learning_rate
         type: float
         default: 2.5e-5
@@ -65,12 +65,24 @@
     parameters:
       - name: base_mistral_model
         default: "mistralai/Mistral-7B-v0.1"
-      - name: prompt
-        type: string
-        default: "You mean Tony Hawk's Pro Skater 3, the 2001 sports game?"
       - name: max_tokens
         type: integer
-        default: 150
+        default: 500
+      - name: prompt
+        type: string
+        default: "
+        Given a meaning representation generate a target sentence that utilizes the attributes and attribute values given. The sentence should use all the information provided in the meaning representation. Below is an example pair. Complete the second pair.
+        ### Meaning representation:
+        inform(name[Need for Speed: Payback], release_year[2017], genres[driving/racing], player_perspective[third person], has_multiplayer[yes], platforms[PlayStation, Xbox, PC], has_linux_release[no], has_mac_release[no])
+        
+        ### Target sentence: 
+        Need for Speed: Payback is a third person driving/racing game with a multiplayer mode. It came out in 2017 for PlayStation, Xbox, and PC, but it is not available on Mac or Linux.
+        
+        ### Meaning representation:
+        inform(name[Made Up Game], release_year[2023], rating[good], genres[arcade, puzzle], has_multiplayer[no], available_on_steam[yes])
+
+        ### Target sentence:
+        "
     inputs:
       - name: finetuned-checkpoint
         default: dataset://mistral-models/best_mistral_checkpoint

--- a/valohai.yaml
+++ b/valohai.yaml
@@ -1,7 +1,7 @@
 - step:
     name: data-preprocess
     image: valohai/llm-toolkit:0.1
-    environment: staging-aws-eu-west-1-p3-2xlarge
+    environment: trial2023-g4dn-xlarge
     command:
       - pip install -r requirements.in
       - python data-preprocess.py {parameters}
@@ -22,7 +22,7 @@
 - step:
     name: finetune
     image: valohai/llm-toolkit:0.1
-    environment: staging-aws-eu-west-1-p3-2xlarge
+    environment: trial2023-g4dn-xlarge
     command:
       - pip install -r requirements.in
       - python finetune-mistral.py {parameters}
@@ -58,7 +58,7 @@
 - step:
     name: inference
     image: valohai/llm-toolkit:0.1
-    environment: staging-aws-eu-west-1-p3-2xlarge
+    environment: trial2023-g4dn-xlarge
     command:
       - pip install -r requirements.in
       - python inference-mistral.py {parameters}


### PR DESCRIPTION
- Change `load_dataset` so it contains the train/test/val splits. The previous approach assumed that each dataset is `train`.
- The whole inference prompt is now a parameter.
- Add `postprocess()` to inference (the model returns lots of spaces in the end)
- Change default  hyperparameters, so the model returns ok results on the first run.